### PR TITLE
Add macOS + zsh 환경 설정 완벽 가이드 (.zprofile vs .zshrc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@
 - [`커머스 팀프로젝트` 개발일지 #15. `📚 학습 및 연구` 일급 컬렉션 vs 확장 함수 (feat. 코틀린 & 자바)](https://github.com/hyunolike/dev-diary/blob/develop/inner-circle/%EC%9D%BC%EA%B8%89%20%EC%BB%AC%EB%A0%89%EC%85%98%20vs%20%ED%99%95%EC%9E%A5%20%ED%95%A8%EC%88%98%20(feat.%20%EC%BD%94%ED%8B%80%EB%A6%B0%20%26%20%EC%9E%90%EB%B0%94).md)
   
 ### 👨‍🌾 개인
+- [`📚 학습 및 연구` macOS + zsh 환경 설정 완벽 가이드 (.zprofile vs .zshrc)](https://github.com/hyunolike/dev-diary/blob/develop/%EA%B0%9C%EC%9D%B8/macOS%20%2B%20zsh%20%ED%99%98%EA%B2%BD%20%EC%84%A4%EC%A0%95%20%EC%99%84%EB%B2%BD%20%EA%B0%80%EC%9D%B4%EB%93%9C%20(.zprofile%20vs%20.zshrc).md)
 - [`📚 학습 및 연구` [Git] rebase 도중 untracked 파일 충돌 원인과 해결 방법](https://github.com/hyunolike/dev-diary/blob/develop/%EA%B0%9C%EC%9D%B8/rebase%20%EB%8F%84%EC%A4%91%20untracked%20%ED%8C%8C%EC%9D%BC%20%EC%B6%A9%EB%8F%8C%20%EC%9B%90%EC%9D%B8%EA%B3%BC%20%ED%95%B4%EA%B2%B0%20%EB%B0%A9%EB%B2%95.md)
 - [`📚 학습 및 연구` JUnit 5 & Mockito 정리](https://github.com/hyunolike/dev-diary/blob/develop/%EA%B0%9C%EC%9D%B8/JUnit%205%20%26%20Mockito%20%EC%A0%95%EB%A6%AC.md)
 - [`📚 학습 및 연구` Git 이미 커밋(푸시)된 일부 파일 제외하는 방법](https://github.com/hyunolike/dev-diary/blob/develop/%EA%B0%9C%EC%9D%B8/Git%20%EC%9D%B4%EB%AF%B8%20%EC%BB%A4%EB%B0%8B(%ED%91%B8%EC%8B%9C)%EB%90%9C%20%EC%9D%BC%EB%B6%80%20%ED%8C%8C%EC%9D%BC%20%EC%A0%9C%EC%99%B8%ED%95%98%EB%8A%94%20%EB%B0%A9%EB%B2%95.md)

--- a/개인/macOS + zsh 환경 설정 완벽 가이드 (.zprofile vs .zshrc).md
+++ b/개인/macOS + zsh 환경 설정 완벽 가이드 (.zprofile vs .zshrc).md
@@ -1,0 +1,129 @@
+# macOS + zsh 환경 설정 완벽 가이드 (.zprofile vs .zshrc)
+
+## 🧭 한 문장 요약
+
+**.zprofile**은 "로그인할 때 한 번 실행"되고,
+**.zshrc**는 "터미널을 열 때마다 실행"된다.
+
+---
+
+## 🧠 개념 정리
+
+| 구분 | .zprofile | .zshrc |
+|------|-----------|---------|
+| **언제 실행됨** | 로그인 시 한 번 (login shell) | 터미널 창 열릴 때마다 (interactive shell) |
+| **실행 주체** | macOS 로그인 / iTerm 첫 실행 | IntelliJ, VSCode, iTerm 새 탭, etc |
+| **역할** | "환경 변수 설정" 중심 | "셸 사용자 설정" 중심 |
+| **IntelliJ 터미널에서 읽힘** | ❌ 안 읽힘 | ✅ 읽힘 |
+| **macOS 기본 터미널에서 읽힘** | ✅ 읽힘 | ✅ 읽힘 |
+| **대표 설정 예시** | PATH, JAVA_HOME, NVM, PYENV | alias, prompt, tmux, export PS1 등 |
+| **호출 관계** | .zprofile → .zshrc (원하면 수동 호출 가능) | 독립 실행 |
+
+---
+
+## 📘 실제 예시
+
+### 🩵 .zprofile (로그인 셸)
+
+macOS 로그인할 때, 시스템 전역 환경을 한 번 세팅
+
+```bash
+# 시스템 PATH 설정 (Homebrew, Java 등)
+export PATH="/opt/homebrew/bin:$PATH"
+export JAVA_HOME=$(/usr/libexec/java_home)
+
+# Node Version Manager 초기화
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+```
+
+> 💡 macOS에서는 GUI 앱들도 이 환경을 상속하기 때문에,
+> 여기 설정이 없으면 IntelliJ·VSCode 같은 앱이 brew, node를 못 찾을 수 있어요.
+
+---
+
+### 💜 .zshrc (인터랙티브 셸)
+
+터미널 새로 열릴 때마다 적용되는 설정
+
+```bash
+# 터미널 인터랙션용 설정
+alias ll='ls -al'
+alias gs='git status'
+
+# 프롬프트, 테마
+export PS1="%n@%m %1~ %# "
+
+# IntelliJ에서 환경이 안 잡히면 아래처럼 중복 선언도 가능
+export PATH="/opt/homebrew/bin:$PATH"
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
+```
+
+> 💡 IntelliJ 터미널은 "비로그인 zsh"로 열리기 때문에
+> .zprofile은 안 읽고 .zshrc만 읽습니다.
+
+---
+
+## ⚙️ 실무 팁
+
+| 상황 | 실행되는 파일 |
+|------|---------------|
+| macOS 로그인 후 첫 터미널 실행 | .zprofile → .zshrc |
+| 새 터미널 탭 열기 | .zshrc만 |
+| IntelliJ, VSCode 터미널 | .zshrc만 |
+| GUI 앱 (IntelliJ, PyCharm 등) 실행 | .zprofile만 (로그인 셸 환경 상속) |
+
+---
+
+## ✅ 정리 요약
+
+| 항목 | .zprofile | .zshrc |
+|------|-----------|---------|
+| **실행 시점** | 로그인 시 (1회) | 터미널 열 때마다 |
+| **IntelliJ 터미널에서 읽힘** | ❌ | ✅ |
+| **macOS 기본 터미널** | ✅ | ✅ |
+| **PATH / NVM / PYENV 설정** | ✅ | ✅ (IDE용 복사 필요) |
+| **alias, prompt 등** | ❌ | ✅ |
+
+---
+
+## 💡 가장 좋은 방법
+
+```bash
+# ~/.zshrc 맨 위에 추가
+if [ -f ~/.zprofile ]; then
+  source ~/.zprofile
+fi
+```
+
+👉 이렇게 하면 IntelliJ 터미널에서도 .zprofile 설정이 함께 불립니다.
+(즉, 한쪽만 관리해도 됨)
+
+---
+
+## 🎯 핵심 포인트
+
+1. **로그인 셸 (Login Shell)**
+   - `.zprofile` 실행
+   - 시스템 전역 환경 변수 설정
+   - GUI 앱들이 이 환경을 상속
+
+2. **인터랙티브 셸 (Interactive Shell)**
+   - `.zshrc` 실행
+   - 터미널 사용자 설정 (alias, prompt 등)
+   - IDE 터미널들은 대부분 이 방식
+
+3. **권장 구조**
+   - 환경 변수 → `.zprofile`
+   - 터미널 설정 → `.zshrc`
+   - IDE 터미널 호환성 → `.zshrc`에서 `.zprofile` source
+
+---
+
+## 📚 참고사항
+
+- macOS는 로그인 시 login shell을 실행하므로 `.zprofile`이 먼저 읽힘
+- 일반적인 터미널 탭은 interactive shell이므로 `.zshrc`만 읽힘
+- IntelliJ, VSCode 등의 IDE 터미널은 interactive non-login shell로 열림
+- 따라서 IDE 터미널에서 PATH가 안 잡히는 문제는 `.zshrc`에 PATH 설정을 추가하거나 `.zprofile`을 source하면 해결됨


### PR DESCRIPTION
macOS 환경에서 자주 헷갈리는 .zprofile과 .zshrc의 차이점과 실무 활용법을 정리한 가이드를 추가했습니다.

- 개인 폴더에 새 가이드 문서 추가
- README.md 개인 섹션에 링크 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)